### PR TITLE
Fix docs focus bug and fallback Prettier config

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,1 +1,13 @@
-module.exports = require('eslint-config-mantine/.prettierrc.js');
+let config;
+try {
+  config = require('eslint-config-mantine/.prettierrc.js');
+} catch (err) {
+  config = {
+    trailingComma: 'es5',
+    tabWidth: 2,
+    semi: true,
+    singleQuote: true,
+    printWidth: 80,
+  };
+}
+module.exports = config;

--- a/components/docs.tsx
+++ b/components/docs.tsx
@@ -102,7 +102,7 @@ export function ColonDocs({ headerMetaData, focus, setFocus, setDrawerOpened }: 
                   key={header.header}
                   onClick={(e) => {
                         e.preventDefault();
-                        setFocus(`${header.header}$}`);
+                        setFocus(`${header.header}$`);
                     }}
                 >
 


### PR DESCRIPTION
## Summary
- fix bug when setting focus in docs page
- use fallback Prettier configuration if mantine config isn't available

## Testing
- `npm test` *(fails: code style issues found)*