### PR TITLE
Remove timeago from explore cards

### DIFF
--- a/components/taskcard.tsx
+++ b/components/taskcard.tsx
@@ -254,15 +254,17 @@ export function TaskCard({
         <Card.Section className={classes.section}>
           <Group position="apart" mt="lg">
             <Group>
-              <Badge
-                radius="xs"
-                size="md"
-                variant={clickable ? 'outline' : 'filled'}
-                color="gray"
-                mt={4}
-              >
-                {format(timestamp_)}
-              </Badge>
+              {!clickable && (
+                <Badge
+                  radius="xs"
+                  size="md"
+                  variant={clickable ? 'outline' : 'filled'}
+                  color="gray"
+                  mt={4}
+                >
+                  {format(timestamp_)}
+                </Badge>
+              )}
               {!clickable && (
                 <Anchor href="#headers">
                   <Badge


### PR DESCRIPTION
## Summary
- update TaskCard to hide the relative time badge when cards are clickable

## Testing
- `npm test` *(fails: `next` not found)*